### PR TITLE
use kafka image with arm64 (Apple M1) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Key|Service|Ports
 `mysql8`|MySQL 8.0|3308
 `redis`|Redis|<ul><li>6379</li><li>8001 (Insights)</li></ul>
 `kafka`|Kafka with Lenses Box|<ul><li>9092 (Kafka broker)</li><li>8081 (Schema Registry)</li><li>3030 (Lenses)</li></ul>
-`mailcatcher`Mailcatcher|<ul><li>1025 (SMTP server)</li><li>1080 (UI)</li></ul>
+`mailcatcher`|Mailcatcher|<ul><li>1025 (SMTP server)</li><li>1080 (UI)</li></ul>
 
 ### MySQL
 

--- a/gdc/docker-compose.yml
+++ b/gdc/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 # ---------- KAFKA ----------
 
   kafka:
-    image: lensesio/box
+    image: nhaidarflipp/kafka-lenses-dev:latest
     environment:
       ADV_HOST: ${KAFKA_ADV_HOST:-127.0.0.1}
       EULA: ${LENSES_KEY}


### PR DESCRIPTION
## Changelog
1. fix table typo in README markdown
2. switch kafka image to [nhaidarflipp/kafka-lenses-dev](https://hub.docker.com/repository/docker/nhaidarflipp/kafka-lenses-dev/tags)

The official lenses box [kafka image](https://github.com/lensesio/fast-data-dev/tree/box/main) and [binary](https://help.lenses.io/using-lenses/basics/architectures/) do not support `arm64` based machines including the M1 MBP. 

There is however an open-source kafka image called [fast-data-dev](https://github.com/lensesio/fast-data-dev/tree/fdd/main) provided by lensesio with less features, that is buildable for `arm64`.

The `nhaidarflipp/kafka-lenses-dev:latest` image is a multi-arch image that uses lenses for `amd64` based machines and fast-data-dev for `arm64`:
| Platform      | Branch   | Underlying image               |
|---------------|----------|---------------------|
| amd64 (intel) | [box/main](https://github.com/nhaidar/fast-data-dev/tree/box/main) | Lenses box 5.0      |
| arm64 (M1)    | [fdd/main](https://github.com/nhaidar/fast-data-dev/tree/fdd/main) | fast-data-dev 3.3.1 |