### PR TITLE
add lenses box support for arm64

### DIFF
--- a/gdc/docker-compose.yml
+++ b/gdc/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 # ---------- KAFKA ----------
 
   kafka:
-    image: nhaidarflipp/kafka-lenses-dev:latest
+    image: lensesio/box
     environment:
       ADV_HOST: ${KAFKA_ADV_HOST:-127.0.0.1}
       EULA: ${LENSES_KEY}


### PR DESCRIPTION
### Changelog

- Switch kafka image back to official lenses box image since [official arm64 support as been added since lenses 5.1](https://ask.lenses.io/t/does-lenses-box-work-with-apple-macbooks-using-the-m1-m2-cpus/22/2). This brings back lenses to those on m1/m2/m3 macbooks. 