### PR TITLE
DP-362 - Add Global Docker Compose Stop

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v3
       with:
         distribution: goreleaser
-        version: latest
+        version: "~> v1"
         args: release --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump version of Redis Insight to V2 and change the exported port to 5540.
 
+[0.7.6] - 2024-03-04
+
+- Bump version to 0.7.6
+- Move to insights v2 (#10)
+
 [0.7.5] - 2024-01-18
 
 - Restore Lenses Box image for Kafka as it now works on arm64.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED
 
-[0.7.6] - 2024-03-04
+[0.11.0] - 2024-06-12
+
+- Add stop command for docker-compose
+- Remove the obsolete version tag from the docker-compose file
+
+[0.10.1] - 2024-05-06
+
+- Fix error on startup
+
+[0.10.0] - 2024-05-02
+
+- Fix for new MySQL 8 images.
+
+[0.9.0] - 2024-03-15
+
+- Build command added
+- Updated version
+
+[0.8.0] - 2024-03-04
 
 - Bump version of Redis Insight to V2 and change the exported port to 5540.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Or you can build it from source by running the following from the root directory
 `global_docker_compose` has multiple sub-commands, most of which should be familiar:
 
 * `global_docker_compose up --service=<service1>,<service2>`: Bring up a list of services as defined by the table below.
-* `global_docker_compose down {service}`: Bring down the specificed service, or all services if not provided.
+* `global_docker_compose down {service}`: Bring down the specified service, or all services if not provided.
 * `global_docker_compose down`: Bring down all services.
+* `global_docker_compose stop --service=<service1>,<service2>`: Stop the specified services, or all services if not provided.
+* `global_docker_compose stop`: Stop all services.
 * `global_docker_compose ps`: Show all running services that were configured using the tool.
 * `global_docker_compose config`: Print out the docker compose config file being used.
 * `global_docker_compose logs {service}`: Print out logs for the specified service, or all services if not provided.

--- a/cmd/gdc/commands/root.go
+++ b/cmd/gdc/commands/root.go
@@ -10,14 +10,16 @@ import (
 )
 
 var cfgFile string
+
 // Services list of services (space delimited)
 var Services string
+
 // ComposeFile optional additional docker-compose.yml file
 var ComposeFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.7.5",
+	Version: "0.8.0",
 	Use:     "global_docker_compose (command) --services service1 service2 --compose_file ../docker-compose.yml",
 	Short:   "Generate JSON files to use with the Flipp platform deploy scripts",
 	Long: `
@@ -29,7 +31,7 @@ var rootCmd = &cobra.Command{
 
          For more information, please see https://github.com/wishabi/global-docker-compose .
 	`,
-	Args:    cobra.ExactArgs(1),
+	Args: cobra.ExactArgs(1),
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/gdc/commands/root.go
+++ b/cmd/gdc/commands/root.go
@@ -19,7 +19,7 @@ var ComposeFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Version: "0.8.0",
+	Version: "0.11.0",
 	Use:     "global_docker_compose (command) --services service1 service2 --compose_file ../docker-compose.yml",
 	Short:   "Generate JSON files to use with the Flipp platform deploy scripts",
 	Long: `

--- a/cmd/gdc/commands/stop.go
+++ b/cmd/gdc/commands/stop.go
@@ -1,0 +1,43 @@
+/*
+Package commands Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package commands
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/wishabi/global-docker-compose/gdc"
+)
+
+// StopCmd represents the stop command
+var StopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop Docker containers",
+	Long: `
+	Stop either specified or all Docker containers.
+
+	Usage: global_docker_compose stop {service}
+				 global_docker_compose stop
+	`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		info := gdc.NewComposeInfo(ComposeFile, Services)
+		gdc.Stop(info)
+		gdc.Cleanup()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(StopCmd)
+}

--- a/gdc/docker-compose.yml
+++ b/gdc/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
 
 # ---------- DATABASES ----------

--- a/gdc/docker.go
+++ b/gdc/docker.go
@@ -124,7 +124,7 @@ func Up(compose ComposeInfo) {
 // Down bring down the Docker containers
 func Down(compose ComposeInfo, service string) {
 	if len(compose.RequestedServices) > 0 {
-		fmt.Printf("Requsted services ,%v", compose.RequestedServices[0])
+		fmt.Printf("Requested services ,%v", compose.RequestedServices[0])
 		var command string
 		if service != "" {
 			command = service
@@ -135,6 +135,16 @@ func Down(compose ComposeInfo, service string) {
 		RunCommand("%s rm -f %s", mainCommand(compose), command)
 	} else {
 		RunCommand("%s down", mainCommand(compose))
+	}
+}
+
+// Stop the Docker containers
+func Stop(compose ComposeInfo) {
+	if len(compose.RequestedServices) > 0 {
+		fmt.Printf("Requested services ,%v", compose.RequestedServices[0])
+		RunCommand("%s stop %s", mainCommand(compose), serviceString(compose, "stop"))
+	} else {
+		RunCommand("%s stop", mainCommand(compose))
 	}
 }
 


### PR DESCRIPTION
- Added the stop command to global docker compose
- Removed the now obsolete version tag from the docker-compose.yml: https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional
- Updated readme
- Updated changelog
- Update to the github action to pull v1 of goreleaser (there is a major version release (v2) which removed some options currently used)